### PR TITLE
Correctly send back details of unhandled Javascript errors from Electron to Nightmare

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -28,8 +28,11 @@ window.__nightmare = {
 // Listen for error events
 window.addEventListener(
   'error',
-  function(err) {
-    send('page', 'error', error(err))
+  function(e) {
+    send('page', 'error', {
+      message: e.message,
+      stack: e.error.stack
+    })
   },
   true
 )


### PR DESCRIPTION
Original seems to be more geared towards handling internal errors, not Javascript ones. As a result it tries to send the `ErrorEvent` which doesn't work, as not all properties are preserved on the nightmare side.

Instead, assume all window errors will have `error` property, which should be correct for Chromium. Remove the nonstandard `code` and `details` properties from here.

Send back error event message, not error message; it more closely matches the original intent
And send back the stack from the `Error` object.